### PR TITLE
fix bug when configureing sumologic sources

### DIFF
--- a/tasks/collector_setup.yml
+++ b/tasks/collector_setup.yml
@@ -9,7 +9,7 @@
 - name: 'Define initial SumoCollector sources'
   set_fact:
     sumologic_collector_log_paths: "{{ sumologic_collector_default_log_path|list + sumologic_collector_application_log_path|list }}"
-  when: sumologic_collector_application_log_path is defined
+  when: sumologic_collector_application_log_path is defined or sumologic_collector_default_log_path is defined
 
 - name: 'Create collector configuration'
   template:


### PR DESCRIPTION
 if sumologic_collector_application_log_path is not defined no sources can be created, even if sumologic_collector_default_log_path is defined